### PR TITLE
FAQ Wi-Fi issues: remove hint to enable notification. no longer needed

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -34,9 +34,7 @@ sections:
           <p><b>Symptom</b>: During onboarding of the device, you cannot connect the device to your Wi-Fi.</p>
           <p><b>Resolution</b>: Try the following steps.
             <ol>
-              <li>On your phone, make sure you have notifications and location enabled for the Home Assistant Companion App.
-                <ul><li>If you are using an Android phone, make sure <b>precise location</b> is enabled.</li></ul>
-              </li>
+              <li>If you are using an Android phone, make sure <b>precise location</b> is enabled.</li>
               <li>If you have different SSIDs  (Wi-Fi names) for the 2.4 GHz and the 5 GHz Wi-Fi networks, make sure you use the credentials for the 2.4 GHz network.</li>
               <li>If you are using a Bluetooth proxy:
                 <ul>


### PR DESCRIPTION
- as now on Android and iPhone the discovery goes via improv, and not the native notification