### PR TITLE
Android location access: remove step

### DIFF
--- a/src/faq.html
+++ b/src/faq.html
@@ -51,7 +51,6 @@ sections:
               </li>
               <li>If you are using an Android phone, make sure <b>precise location</b> is enabled.<ul>
                 <li>Go to <b>Settings</b> > <b>Apps</b> > <b>Home Assistant</b> > <b>Permissions</b> and enable <b>Location</b>, <b>Allow all the time</b> and <b>Use precise location</b>.</li>
-                <li>In the Companion app, go to <b>Settings</b> > <b>Companion app</b> > <b>Manage sensors</b> and enable the <b>Location sensors</b>.</li>
               </ul></li>
               <li>If you have different <abbr title="Service set identifier = Wi-Fi network name">SSIDs</abbr>  (Wi-Fi names) for the 2.4&nbsp;GHz and the 5&nbsp;GHz Wi-Fi networks, make sure you use the credentials for the 2.4&nbsp;GHz network.</li>
               <li>If you are using a Bluetooth proxy:

--- a/src/guides/getting-started.html
+++ b/src/guides/getting-started.html
@@ -43,7 +43,6 @@ tools:
         <li>For Android: make sure you’ve enabled precise location service permissions for Home Assistant. It is used for onboarding only. You can disable it again afterward.
           <ul>
             <li>Go to <b>Settings</b> > <b>Apps</b> > <b>Home Assistant</b> > <b>Permissions</b> and enable <b>Location</b>, <b>Allow all the time</b> and <b>Use precise location</b>.</li>
-            <li>In the Companion app, go to <b>Settings</b> > <b>Companion app</b> > <b>Manage sensors</b> and enable the <b>Location sensors</b>.</li>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
- remove step to enable location sensors in the companion app
- if location access is not granted on the phone to HA, the user will be prompted.