### PR TITLE
Clarify that the rubber pads are not glued

### DIFF
--- a/src/guides/guides.11tydata.yaml
+++ b/src/guides/guides.11tydata.yaml
@@ -371,7 +371,7 @@ procedureDisassemble:
       image: 01_remove_pads_small.png
       content: |
         <ol>
-          <li>Remove the 4 rubber pads.</li>
+          <li>Remove the 4 rubber pads (they are not glued in).</li>
           <li>Take the crosshead screwdriver and unscrew the 4 screws.</li>
         </ol>
     - title: Remove the top enclosure


### PR DESCRIPTION
The first time I wanted to disassemble my Voice PE, I hesitated because I assumed that the rubber pads were glued on, like they usually are. It was a lovely surprise to find them friction-fitted!